### PR TITLE
Added filters to /api/search/ User story #172

### DIFF
--- a/stack_overfull/frontend/src/components/SearchFiltersBar/index.jsx
+++ b/stack_overfull/frontend/src/components/SearchFiltersBar/index.jsx
@@ -4,7 +4,14 @@ import {Tag} from "antd"
 
 const CheckableTag = Tag.CheckableTag;
 
+/* All filters supported by backend
+  'head', 'text', 'username', 'tags','answered', 'notanswered', 'accepted', 'notaccepted'
+*/
+
+// Filters that can be selected by users
 const filterNames = ['head', 'text', 'username', 'tags', 'answered', 'accepted']
+
+// Names for filters that are displayed for users
 const filterDisplayNames = ['Header', 'Text', 'Usernames', 'Tags', 'Answered', 'Accepted'];
 
 export class SearchFiltersBar extends React.Component {

--- a/stack_overfull/frontend/src/components/SearchFiltersBar/index.jsx
+++ b/stack_overfull/frontend/src/components/SearchFiltersBar/index.jsx
@@ -4,8 +4,8 @@ import {Tag} from "antd"
 
 const CheckableTag = Tag.CheckableTag;
 
-const filterNames = ['header', 'text', 'username', 'tags', 'notanswered', 'notaccepted']
-const filterDisplayNames = ['Header', 'Text', 'Usernames', 'Tags', 'No Answers', 'Not Accepted'];
+const filterNames = ['head', 'text', 'username', 'tags', 'answered', 'accepted']
+const filterDisplayNames = ['Header', 'Text', 'Usernames', 'Tags', 'Answered', 'Accepted'];
 
 export class SearchFiltersBar extends React.Component {
   constructor(props) {

--- a/stack_overfull/so_endpoint/serializers.py
+++ b/stack_overfull/so_endpoint/serializers.py
@@ -41,10 +41,17 @@ class TagViewSerializer(serializers.ModelSerializer):
 
 class QuestionSerializer(serializers.ModelSerializer):
     user_id = AccountSerializer(read_only=True)
+    answer_count = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Question
-        fields = ('id', 'user_id', 'question_head', 'question_text', 'accepted_answer_id', 'rejected_answers_ids', 'date_created', 'points', 'tags')
+        fields = ('id', 'user_id', 'question_head', 'question_text',
+                'accepted_answer_id', 'rejected_answers_ids', 'date_created',
+                'answer_count', 'points', 'tags')
+
+    def get_answer_count(self, question):
+        return len(question.answer_set.all())
+
 
 class AnswerSerializer(serializers.ModelSerializer):
     user_id = AccountSerializer(read_only=True)

--- a/stack_overfull/so_endpoint/tests.py
+++ b/stack_overfull/so_endpoint/tests.py
@@ -340,7 +340,7 @@ class QuestionViewTest(TestCase):
             "order": "asc",
             "limit": 20,
             "sort": "date_created",
-            "tags": ['testtag']
+            "tags[]": ['testtag']
         }
 
         response = self.client.get('/api/question/', data)

--- a/stack_overfull/so_endpoint/views.py
+++ b/stack_overfull/so_endpoint/views.py
@@ -11,6 +11,7 @@ from django.views.generic import TemplateView
 from django.views.decorators.csrf import csrf_exempt
 from django.http import JsonResponse
 from django.contrib.auth import authenticate, login, logout
+from django.db.models import Count
 
 from so_endpoint.serializers import (QuestionSerializer, AnswerSerializer,
                                      AccountSerializerPrivate, AccountSerializerPublic,
@@ -69,7 +70,7 @@ class QuestionView(TemplateView):
         q_id = request.GET.get('id', None)
         order = request.GET.get('order', 'desc')
         sorted_by = request.GET.get('sort', 'points')
-        tags = request.GET.getlist('tags', list())
+        tags = request.GET.getlist('tags[]', list())
 
         if q_id is None:
             # If q_id is not set then it returns a list of questions
@@ -559,7 +560,10 @@ class QuestionVoteView(TemplateView):
 class SearchView(TemplateView):
     """
     This view handles the /api/search/ endpoint
-    It returns a list of questions matching a query
+    It returns a list of questions matching a query and filters array
+    The filters array can contain any of:
+        ('head', 'text', 'username', 'tags',
+         'answered', 'notanswered', 'accepted', 'notaccepted')
     """
     @method_decorator(csrf_exempt)
     def dispatch(self, request, *args, **kwargs):
@@ -571,20 +575,70 @@ class SearchView(TemplateView):
             limit = request.GET.get('limit', 10)
             order = request.GET.get('order', 'desc')
             sorted_by = request.GET.get('sort', 'date_created')
+            filters = request.GET.getlist('filters[]', list())
 
             limit = int(limit)
             modifier = '-' if order == "desc" else ''
 
-            # filter questions by case-insensitive matching with question_text
-            by_question_text = Question.objects.filter(
-                question_text__icontains=query)
-            by_question_head = Question.objects.filter(
-                question_head__icontains=query)
-            # filter questions by case-insensitive matching with username
-            by_username = Question.objects.filter(
-                user_id__username__icontains=query)
+            filters = list() if filters is None else filters
 
-            matching_questions = by_question_head | by_question_text | by_username
+            # has_filters is true if any of the fitlers in filters[]
+            # depends on the search query ('q') parameter
+            if set(filters).intersection(['head', 'text', 'tags', 'username']):
+                has_filters = True
+            else:
+                has_filters = False
+
+            by_question_head = Question.objects.none()
+            by_question_text = Question.objects.none()
+            by_username      = Question.objects.none()
+            by_tags          = Question.objects.none()
+
+            # filter questions by case-insensitive matching with question_head
+            if has_filters is False or 'head' in filters:
+                by_question_head = Question.objects.filter(
+                    question_head__icontains=query)
+
+            # filter questions by case-insensitive matching with question_text
+            if has_filters is False or 'text' in filters:
+                by_question_text = Question.objects.filter(
+                    question_text__icontains=query)
+
+            # filter questions by case-insensitive matching with username
+            if has_filters is False or 'username' in filters:
+                by_username = Question.objects.filter(
+                    user_id__username__icontains=query)
+
+            # filter questions by case-insensitive matching with tags
+            if has_filters is False or 'tags' in filters:
+                by_tags = Question.objects.filter(
+                    tags__tag_text__icontains=query)
+
+            # find answered questions set
+            # https://stackoverflow.com/questions/258296/django-models-how-to-filter-number-of-foreignkey-objects
+            answered_set = Question.objects.all().annotate(
+                answers_count=Count('answer')
+            ).filter(answers_count__gt=0)
+
+            #Get a new answered_set without the answers_count annotation
+            answered_set = Question.objects.filter(pk__in=answered_set)
+
+            # find accepted questions set
+            accepted_set = Question.objects.all().filter(
+                accepted_answer_id__isnull=False)
+
+            matching_questions = by_question_head | by_question_text | by_username | by_tags
+            matching_questions = matching_questions.distinct()  # remove duplicates
+
+            if 'answered' in filters:
+                matching_questions = matching_questions.intersection( answered_set )
+            elif 'notanswered' in filters:
+                matching_questions = matching_questions.difference( answered_set )
+
+            if 'accepted' in filters:
+                matching_questions = matching_questions.intersection( accepted_set )
+            elif 'notaccepted' in filters:
+                matching_questions = matching_questions.difference( accepted_set )
 
             matching_questions = matching_questions.order_by(
                 modifier+sorted_by)[:limit]


### PR DESCRIPTION
Added filters to /api/search/ User story #172

- added optional filters[] array to the query parameters of /api/search/
- filters[] can contain any of 'head', 'text', 'username', 'tags', 
'answered', 'notanswered', 'accepted', 'notaccepted'
- if filters[] is not present the 'head', 'text', 'username', and 'tags' filters are used
- added brackets to GET query parameters to handle arrays sent by axios
- added answer_count parameter to QuestionSerializer
- added comments to SearchFiltersBar